### PR TITLE
README: Update project wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # roblox-assets-grab
 
-More information about the archiving project can be found on the ArchiveTeam wiki: [Roblox assets](https://wiki.archiveteam.org/index.php/Roblox_assets)
+More information about the archiving project can be found on the ArchiveTeam wiki: [Roblox](https://wiki.archiveteam.org/index.php/Roblox)
 
 ## Setup instructions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # roblox-assets-grab
 
-More information about the archiving project can be found on the ArchiveTeam wiki: [Roblox assets](https://wiki.archiveteam.org/index.php?title=Roblox assets)
+More information about the archiving project can be found on the ArchiveTeam wiki: [Roblox assets](https://wiki.archiveteam.org/index.php/Roblox_assets)
 
 ## Setup instructions
 


### PR DESCRIPTION
The previous link had a space in it, which broke Markdown rendering. ~~I updated it to what I assume is the intended URL, even though that page doesn't exist yet on the wiki.~~

I updated it to point to the main Roblox page since a page for the project doesn’t exist. 